### PR TITLE
atac_trim_barcode fastq approach new outputs

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -138,7 +138,7 @@ char* getFileName(const char* cpath, const char* seperator)
     return path;
 }
 
-char* createFileWithAppend(char* fq_out, const char* appendR1, char* fq1_fn){
+char* createFileWithAppend(const char *fq_out, const char* appendR1, const char *fq1_fn){
     char* fqoutR1 = (char*)malloc(strlen(fq_out) + strlen(appendR1) + strlen(getFileName(fq1_fn)) + 1);
     strcpy(fqoutR1, fq_out);
     strcat(fqoutR1,appendR1);

--- a/src/utils.h
+++ b/src/utils.h
@@ -46,7 +46,7 @@ std::string padding(int count, int zero_num);
 void file_error(const char *filename);
 
 char* getFileName(const char* path, const char* seperator = "/");
-char* createFileWithAppend(char* fq_out, const char* appendR1, char* fq1_fn);
+char* createFileWithAppend(const char *fq_out, const char* appendR1, const char *fq1_fn);
 void openFile(gzFile &o_stream_gz_R1,std::ofstream &o_stream_R1, char* fqoutR1, bool write_gz);
 #endif
 


### PR DESCRIPTION
- outputs to full, partial and no match files based on matching barcode sequences against valid_barcode file:
    - requires all barcode fastq files to match to output to full match
    - requires at least one to fully or partially  match to output to partial match
    - all others are output to no match